### PR TITLE
Replace testCompile with testImplementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ dependencies {
             strictly '2.13.11'
         }
     }
-    testCompile('org.junit.vintage:junit-vintage-engine:5.9.0')
-    testCompile("org.scalatest:scalatest_${scalaMajorVersion}:3.0.9")
+    testImplementation('org.junit.vintage:junit-vintage-engine:5.9.0')
+    testImplementation("org.scalatest:scalatest_${scalaMajorVersion}:3.0.9")
 }
 
 


### PR DESCRIPTION
testCompile has been removed in Gradle 7 which means students using this or a later version are unable to run the code.