### PR TITLE
Add test case to indexOfMaxTests for different maximum positions

### DIFF
--- a/test/warmup/IndexOfMaxTests.scala
+++ b/test/warmup/IndexOfMaxTests.scala
@@ -62,4 +62,11 @@ class IndexOfMaxTests extends TestBase {
 
         assert(actual == expected)
     }
+
+    test("max8") {
+        val actual = Exercises.indexOfMax(Array(1, 2, 3, 2, 1, 6))
+        val expected = 5
+
+        assert(actual == expected)
+    }
 }


### PR DESCRIPTION
### Fix indexOfMax Function and Add Test Cases

This pull request fixes a bug in the indexOfMax where a student can increase the index each time they encounter a maximum, and still pass IndexOfMaxTests.  The added test case prevents this, by ensuring that the function correctly identifies the index of the maximum value, **even when it appears later in the array**.